### PR TITLE
feat: filterByTimeInterval preparate to .csv

### DIFF
--- a/src/controllers/communicationReportController.ts
+++ b/src/controllers/communicationReportController.ts
@@ -93,6 +93,23 @@ const communicationReportController = (
       next(error);
     }
   },
+
+  getReportsByTimeInterval: async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const { startDate, endDate } = req.body;
+      const reports = await service.getReportsByTimeInterval(
+        startDate,
+        endDate
+      );
+      res.json(reports);
+    } catch (error) {
+      next(error);
+    }
+  },
 });
 
 export default communicationReportController;

--- a/src/repositories/communicationReportRepository.ts
+++ b/src/repositories/communicationReportRepository.ts
@@ -103,6 +103,26 @@ const communicationReportRepository = (knex: Knex) => ({
       .select("locomotive.name as locomotive", "failure_types.failure_type")
       .count("* as count")
       .groupBy("locomotive.name", "failure_types.failure_type"),
+
+  findByTimeInterval: (startDate: Date, endDate: Date) =>
+    knex("communication_report")
+      .join(
+        "failure_types",
+        "communication_report.subject_id",
+        "failure_types.id"
+      )
+      .join("user", "communication_report.created_by_id", "user.id")
+      .join("driver", "communication_report.driver_id", "driver.id")
+      .join("locomotive", "communication_report.locomotive_id", "locomotive.id")
+      .whereBetween("communication_report.created_at", [startDate, endDate])
+      .select([
+        "communication_report.*",
+        "failure_types.failure_type as subject",
+        "user.name as created_by",
+        "driver.name as driver",
+        "locomotive.name as locomotive",
+      ])
+      .orderBy("communication_report.created_at", "asc"),
 });
 
 export default communicationReportRepository;

--- a/src/routes/communicationReportRoutes.ts
+++ b/src/routes/communicationReportRoutes.ts
@@ -21,10 +21,13 @@ router.get(
   "/filterbysubjectid/:subjectId",
   controller.getReportCountBySubjectLastThreeMonths
 );
+
 router.post(
-  "/filterbytimeinterval",
+  "/countbytimeinterval",
   controller.getErrorCountByLocomotiveAndTimeInterval
 );
+router.post("/filterbytimeinterval", controller.getReportsByTimeInterval);
+
 router.get("/filterbysubjectanddays/:days", async (req, res) => {
   const days = Number(req.params.days);
   const result = await service.groupReportsByDate(days);

--- a/src/services/communicationReportServices.ts
+++ b/src/services/communicationReportServices.ts
@@ -86,6 +86,17 @@ const communicationReportService = (
       count: parseInt(errorCount.count as string),
     }));
   },
+
+  getReportsByTimeInterval: async (
+    startDate: Date,
+    endDate: Date
+  ): Promise<ReportType[]> => {
+    const reports: ReportType[] = await repo.findByTimeInterval(
+      startDate,
+      endDate
+    );
+    return reports.map(formatReportDateAndTime);
+  },
 });
 
 export default communicationReportService;


### PR DESCRIPTION
## 📝 Descrição

Alterei a rota que anteriormente estava definida como /filterbytimeinterval no método post para /countbytimeinterval para que a nomeclatura se adaptasse melhor a sua real função. 

Criei a verdadeira rota /filterbytimeinterval que também utiliza o método post, dessa vez para de fato puxar todos os dados e detalhes dos relatórios em um intervalo de tempo. 

esta rota é uma preparação para a função de exportar relatórios em intervalo de tempo no formato excel. 
<img width="364" alt="Captura de tela 2023-07-04 185012" src="https://github.com/AcademyRethink/backend-jedi-order/assets/124932698/7e017ff4-0848-4770-8e1e-540b707650cb">


O objeto esperado é

`{
  "startDate": "2022-07-02",
  "endDate": "2023-07-04"
}`


## 📚 Checklist

- [x]  Realizei uma auto-revisão do meu próprio código
- [x]  O código segue as diretrizes de estilo deste projeto
- [x]  Comentei meu código em áreas necessárias
- [x]  Fiz as alterações correspondentes na documentação
- [ ]  Testes de unidade novos e existentes são aprovados localmente com minhas alterações

## 🚚 Tipo da alteração

- New feature (Alteração que adiciona novas funcionalidades)
- Refactor (Alteração ou correção de funcionalidades existentes)
<img width="638" alt="Captura de tela 2023-07-04 184905" src="https://github.com/AcademyRethink/backend-jedi-order/assets/124932698/5552d5b7-43f3-48ef-8c3e-38e79b13a551">
